### PR TITLE
Fix double plugin bug

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -6,6 +6,7 @@ module.exports = {
     'airbnb-base',
   ],
   rules: {
+    'no-param-reassign': [2, { props: false }],
     'import/extensions': 0,
     'import/no-extraneous-dependencies': 0,
     'import/no-unresolved': 0,

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -90,7 +90,7 @@ function getRealPathFromRegExpConfig(sourcePath, regExps) {
   return aliasedSourceFile;
 }
 
-export default function getRealPath(sourcePath, { file, opts, cwd }) {
+export default function getRealPath(sourcePath, { file, opts }) {
   if (sourcePath[0] === '.') {
     return sourcePath;
   }
@@ -100,7 +100,7 @@ export default function getRealPath(sourcePath, { file, opts, cwd }) {
   const currentFile = file.opts.filename;
   const absCurrentFile = path.resolve(currentFile);
 
-  const { root, extensions, alias, regExps } = opts;
+  const { cwd, root, extensions, alias, regExps } = opts;
 
   const sourceFileFromRoot = getRealPathFromRootConfig(
     sourcePath, absCurrentFile, root, cwd, extensions,

--- a/src/index.js
+++ b/src/index.js
@@ -17,7 +17,6 @@ function isRegExp(string) {
 
 export function manipulatePluginOptions(pluginOpts) {
   if (pluginOpts.root) {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.root = pluginOpts.root.reduce((resolvedDirs, dirPath) => {
       if (glob.hasMagic(dirPath)) {
         return resolvedDirs.concat(
@@ -27,11 +26,9 @@ export function manipulatePluginOptions(pluginOpts) {
       return resolvedDirs.concat(dirPath);
     }, []);
   } else {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.root = [];
   }
 
-  // eslint-disable-next-line no-param-reassign
   pluginOpts.regExps = [];
 
   if (pluginOpts.alias) {
@@ -50,16 +47,13 @@ export function manipulatePluginOptions(pluginOpts) {
 
         pluginOpts.regExps.push([new RegExp(key), substitute]);
 
-        // eslint-disable-next-line no-param-reassign
         delete pluginOpts.alias[key];
       });
   } else {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.alias = {};
   }
 
   if (!pluginOpts.extensions) {
-    // eslint-disable-next-line no-param-reassign
     pluginOpts.extensions = defaultExtensions;
   }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -361,6 +361,27 @@ describe('module-resolver', () => {
         );
       });
     });
+
+    describe('with the plugin applied twice', () => {
+      const doubleAliasTransformerOpts = {
+        plugins: [
+          [plugin, { root: ['.'] }],
+          [plugin, {
+            alias: {
+              '^@namespace/foo-(.+)': 'packages/\\1',
+            },
+          }],
+        ],
+      };
+
+      it('should support replacing parts of a path', () => {
+        testWithImport(
+          '@namespace/foo-bar',
+          'packages/bar',
+          doubleAliasTransformerOpts,
+        );
+      });
+    });
   });
 
   describe('with custom cwd', () => {


### PR DESCRIPTION
This fixes https://github.com/tleunen/babel-plugin-module-resolver/issues/148.

The plugin was broken when it was included twice: the options in the second plugin were not being normalized. The RegExp feature and also the big refactor (#2) caused this bug to surface.

`pre` is a better place than `manipulateOptions` to handle default options, so normalization should be moved there.