### PR TITLE
Use CWD for the glob patterns

### DIFF
--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -6,14 +6,14 @@ import mapToRelative from 'mapToRelative';
 import { toLocalPath, toPosixPath, replaceExtension } from 'utils';
 
 
-function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
+function findPathInRoots(sourcePath, rootDirs, extensions) {
   // Search the source path inside every custom root directory
   let resolvedSourceFile;
-  rootDirs.some((dir) => {
+  rootDirs.some((basedir) => {
     try {
       // check if the file exists (will throw if not)
       resolvedSourceFile = requireResolve.sync(`./${sourcePath}`, {
-        basedir: resolve(cwd, dir),
+        basedir,
         extensions,
       });
       return true;
@@ -26,7 +26,7 @@ function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
 }
 
 function getRealPathFromRootConfig(sourcePath, absCurrentFile, rootDirs, cwd, extensions) {
-  const absFileInRoot = findPathInRoots(sourcePath, rootDirs, cwd, extensions);
+  const absFileInRoot = findPathInRoots(sourcePath, rootDirs, extensions);
 
   if (!absFileInRoot) {
     return null;

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -28,19 +28,19 @@ function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
 function getRealPathFromRootConfig(sourcePath, absCurrentFile, rootDirs, cwd, extensions) {
   const absFileInRoot = findPathInRoots(sourcePath, rootDirs, cwd, extensions);
 
-  if (absFileInRoot) {
-    const realSourceFileExtension = extname(absFileInRoot);
-    const sourceFileExtension = extname(sourcePath);
-
-    // map the source and keep its extension if the import/require had one
-    const ext = realSourceFileExtension === sourceFileExtension ? realSourceFileExtension : '';
-    return toLocalPath(toPosixPath(replaceExtension(
-      mapToRelative(cwd, absCurrentFile, absFileInRoot),
-      ext,
-    )));
+  if (!absFileInRoot) {
+    return null;
   }
 
-  return null;
+  const realSourceFileExtension = extname(absFileInRoot);
+  const sourceFileExtension = extname(sourcePath);
+
+  // map the source and keep its extension if the import/require had one
+  const ext = realSourceFileExtension === sourceFileExtension ? realSourceFileExtension : '';
+  return toLocalPath(toPosixPath(replaceExtension(
+    mapToRelative(cwd, absCurrentFile, absFileInRoot),
+    ext,
+  )));
 }
 
 function getRealPathFromAliasConfig(sourcePath, absCurrentFile, alias, cwd) {

--- a/src/getRealPath.js
+++ b/src/getRealPath.js
@@ -1,6 +1,6 @@
-import path from 'path';
+import { extname, resolve } from 'path';
 
-import resolve from 'resolve';
+import requireResolve from 'resolve';
 
 import mapToRelative from 'mapToRelative';
 import { toLocalPath, toPosixPath, replaceExtension } from 'utils';
@@ -12,8 +12,8 @@ function findPathInRoots(sourcePath, rootDirs, cwd, extensions) {
   rootDirs.some((dir) => {
     try {
       // check if the file exists (will throw if not)
-      resolvedSourceFile = resolve.sync(`./${sourcePath}`, {
-        basedir: path.resolve(cwd, dir),
+      resolvedSourceFile = requireResolve.sync(`./${sourcePath}`, {
+        basedir: resolve(cwd, dir),
         extensions,
       });
       return true;
@@ -29,8 +29,8 @@ function getRealPathFromRootConfig(sourcePath, absCurrentFile, rootDirs, cwd, ex
   const absFileInRoot = findPathInRoots(sourcePath, rootDirs, cwd, extensions);
 
   if (absFileInRoot) {
-    const realSourceFileExtension = path.extname(absFileInRoot);
-    const sourceFileExtension = path.extname(sourcePath);
+    const realSourceFileExtension = extname(absFileInRoot);
+    const sourceFileExtension = extname(sourcePath);
 
     // map the source and keep its extension if the import/require had one
     const ext = realSourceFileExtension === sourceFileExtension ? realSourceFileExtension : '';
@@ -98,7 +98,7 @@ export default function getRealPath(sourcePath, { file, opts }) {
   // file param is a relative path from the environment current working directory
   // (not from cwd param)
   const currentFile = file.opts.filename;
-  const absCurrentFile = path.resolve(currentFile);
+  const absCurrentFile = resolve(currentFile);
 
   const { cwd, root, extensions, alias, regExps } = opts;
 

--- a/src/index.js
+++ b/src/index.js
@@ -1,5 +1,5 @@
 import fs from 'fs';
-import { dirname } from 'path';
+import { dirname, resolve } from 'path';
 
 import findBabelConfig from 'find-babel-config';
 import glob from 'glob';
@@ -40,16 +40,18 @@ function normalizePluginOptions(file) {
   normalizeCwd.call(this, file);
 
   if (opts.root) {
-    opts.root = opts.root.reduce((resolvedDirs, dirPath) => {
-      if (glob.hasMagic(dirPath)) {
-        const roots = glob.sync(dirPath)
-          .filter(path => fs.lstatSync(path).isDirectory());
+    opts.root = opts.root
+      .map(dirPath => resolve(opts.cwd, dirPath))
+      .reduce((resolvedDirs, absDirPath) => {
+        if (glob.hasMagic(absDirPath)) {
+          const roots = glob.sync(absDirPath)
+            .filter(path => fs.lstatSync(path).isDirectory());
 
-        return [...resolvedDirs, ...roots];
-      }
+          return [...resolvedDirs, ...roots];
+        }
 
-      return [...resolvedDirs, dirPath];
-    }, []);
+        return [...resolvedDirs, absDirPath];
+      }, []);
   } else {
     opts.root = [];
   }

--- a/src/index.js
+++ b/src/index.js
@@ -42,12 +42,13 @@ function normalizePluginOptions(file) {
   if (opts.root) {
     opts.root = opts.root.reduce((resolvedDirs, dirPath) => {
       if (glob.hasMagic(dirPath)) {
-        return resolvedDirs.concat(
-          glob.sync(dirPath)
-            .filter(path => fs.lstatSync(path).isDirectory()),
-        );
+        const roots = glob.sync(dirPath)
+          .filter(path => fs.lstatSync(path).isDirectory());
+
+        return [...resolvedDirs, ...roots];
       }
-      return resolvedDirs.concat(dirPath);
+
+      return [...resolvedDirs, dirPath];
     }, []);
   } else {
     opts.root = [];

--- a/src/mapToRelative.js
+++ b/src/mapToRelative.js
@@ -1,23 +1,15 @@
-import path from 'path';
+import { dirname, normalize, relative, resolve } from 'path';
 
 import { toPosixPath } from 'utils';
 
 
-function resolve(cwd, filename) {
-  if (path.isAbsolute(filename)) {
-    return filename;
-  }
-
-  return path.resolve(cwd, filename);
-}
-
 export default function mapToRelative(cwd, currentFile, module) {
-  let from = path.dirname(currentFile);
-  let to = path.normalize(module);
+  let from = dirname(currentFile);
+  let to = normalize(module);
 
   from = resolve(cwd, from);
   to = resolve(cwd, to);
 
-  const moduleMapped = path.relative(from, to);
+  const moduleMapped = relative(from, to);
   return toPosixPath(moduleMapped);
 }

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-import { join } from 'path';
+import { resolve } from 'path';
 
 import { transform } from 'babel-core';
 
@@ -390,13 +390,11 @@ describe('module-resolver', () => {
         babelrc: false,
         plugins: [
           [plugin, {
-            root: [
-              './testproject/src',
-            ],
+            root: ['./testproject/src'],
             alias: {
               test: './testproject/test',
             },
-            cwd: join(process.cwd(), 'test'),
+            cwd: resolve('test'),
           }],
         ],
       };
@@ -417,6 +415,46 @@ describe('module-resolver', () => {
         );
       });
     });
+
+    describe('with root', () => {
+      const transformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            root: ['./src'],
+            cwd: resolve('test/testproject'),
+          }],
+        ],
+      };
+
+      it('should resolve the sub file path', () => {
+        testWithImport(
+          'components/Root',
+          './test/testproject/src/components/Root',
+          transformerOpts,
+        );
+      });
+    });
+
+    describe('with glob root', () => {
+      const transformerOpts = {
+        babelrc: false,
+        plugins: [
+          [plugin, {
+            root: ['./src/**'],
+            cwd: resolve('test/testproject'),
+          }],
+        ],
+      };
+
+      it('should resolve the sub file path', () => {
+        testWithImport(
+          'components/Root',
+          './test/testproject/src/components/Root',
+          transformerOpts,
+        );
+      });
+    });
   });
 
   describe('babelrc', () => {
@@ -424,9 +462,7 @@ describe('module-resolver', () => {
       babelrc: false,
       plugins: [
         [plugin, {
-          root: [
-            './src',
-          ],
+          root: ['./src'],
           alias: {
             test: './test',
           },

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import { join } from 'path';
 
 import { transform } from 'babel-core';
 
@@ -396,7 +396,7 @@ describe('module-resolver', () => {
             alias: {
               test: './testproject/test',
             },
-            cwd: path.join(process.cwd(), 'test'),
+            cwd: join(process.cwd(), 'test'),
           }],
         ],
       };

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -441,8 +441,8 @@ describe('module-resolver', () => {
         babelrc: false,
         plugins: [
           [plugin, {
-            root: ['./src/**'],
-            cwd: resolve('test/testproject'),
+            root: ['./testproject/*'],
+            cwd: resolve('test'),
           }],
         ],
       };

--- a/test/mapToRelative.test.js
+++ b/test/mapToRelative.test.js
@@ -1,4 +1,4 @@
-import path from 'path';
+import { resolve } from 'path';
 
 import mapToRelative from 'mapToRelative';
 
@@ -7,14 +7,14 @@ describe('mapToRelative', () => {
   describe('should map to relative path with a custom cwd', () => {
     it('with a relative filename', () => {
       const currentFile = './utils/test/file.js';
-      const result = mapToRelative(path.resolve('./test'), currentFile, 'utils/dep');
+      const result = mapToRelative(resolve('./test'), currentFile, 'utils/dep');
 
       expect(result).toBe('../dep');
     });
 
     it('with an absolute filename', () => {
-      const currentFile = path.join(process.cwd(), './utils/test/file.js');
-      const result = mapToRelative(process.cwd(), currentFile, 'utils/dep');
+      const currentFile = resolve('./utils/test/file.js');
+      const result = mapToRelative(resolve('.'), currentFile, 'utils/dep');
 
       expect(result).toBe('../dep');
     });


### PR DESCRIPTION
Related to https://github.com/tleunen/babel-plugin-module-resolver/pull/137.

The `cwd` option should be used when resolving the globbing patterns.

Edit:
It turns out that ignoring the `cwd` option for the `root` glob resolving was causing a bug. The paths found by glob could come from some other (non-custom-cwd) directory, which was inconsistent with non-glob paths.

As a result of those changes, `opts.cwd` will be used to resolve all the root paths, especially before resolving the glob patterns.